### PR TITLE
shout: Remove chance of SQL injection.

### DIFF
--- a/commands/shout.js
+++ b/commands/shout.js
@@ -19,7 +19,8 @@ module.exports = class Shout extends Command {
     }
 
     if (query) {
-      row = await db.one(`SELECT * FROM shouts WHERE message LIKE '%${query.toUpperCase()}%' ORDER BY random() LIMIT 1`)
+      let pattern = `%${query.toUpperCase()}%`
+      row = await db.one('SELECT * FROM shouts WHERE message LIKE $1 ORDER BY random() LIMIT 1', [pattern])
     } else {
       row = await db.one('SELECT * FROM shouts ORDER BY random() LIMIT 1', [])
     }


### PR DESCRIPTION
Given that the query is erased when ';' is present and the query is uppercased, there's not too much fun stuff that can be injected. Still, remove this avenue of exploitation before someone figures out something clever to do with it.

See https://github.com/strong-code/botto/issues/32